### PR TITLE
Whitelist ducc_.* functions

### DIFF
--- a/ducc-sys/src/ffi_gen.rs
+++ b/ducc-sys/src/ffi_gen.rs
@@ -8,6 +8,7 @@ fn main() {
         .rust_target(bindgen::RustTarget::Stable_1_25)
         .whitelist_type("^(?:rust_)?duk_.*")
         .whitelist_function("^(?:rust_)?duk_.*")
+        .whitelist_function("^(?:rust_)?ducc_.*")
         .whitelist_var("^DUK_.*")
         .generate()
         .expect("failed to generate bindings")


### PR DESCRIPTION
Allow bindgen to include bindings for `ducc_.*` functions so the following functions are accessible:

* `ffi::ducc_push_c_function_nothrow`
* `ffi::ducc_set_exec_timeout_function`