### PR TITLE
Fix deprecation warnings

### DIFF
--- a/ducc/src/ducc.rs
+++ b/ducc/src/ducc.rs
@@ -103,7 +103,7 @@ impl Ducc {
     /// Inserts any sort of keyed value of type `T` into the `Ducc`, typically for later retrieval
     /// from within Rust functions called from within JavaScript. If a value already exists with the
     /// key, it is returned.
-    pub fn set_user_data<K, T>(&mut self, key: K, data: T) -> Option<Box<Any + 'static>>
+    pub fn set_user_data<K, T>(&mut self, key: K, data: T) -> Option<Box<dyn Any + 'static>>
     where
         K: ToString,
         T: Any + 'static,
@@ -129,7 +129,7 @@ impl Ducc {
 
     /// Removes and returns a user data value by its key. Returns `None` if no value exists with the
     /// key.
-    pub fn remove_user_data(&mut self, key: &str) -> Option<Box<Any + 'static>> {
+    pub fn remove_user_data(&mut self, key: &str) -> Option<Box<dyn Any + 'static>> {
         unsafe {
             let any_map = get_any_map(self.ctx);
             (*any_map).remove(key)
@@ -436,5 +436,5 @@ pub struct ExecSettings {
     /// possible, or `false` if the execution should continue. This is useful for implementing an
     /// execution timeout. This function is only called during JavaScript execution, and will not be
     /// called while execution is within native Rust code.
-    pub cancel_fn: Option<Box<Fn() -> bool>>,
+    pub cancel_fn: Option<Box<dyn Fn() -> bool>>,
 }

--- a/ducc/src/error.rs
+++ b/ducc/src/error.rs
@@ -45,7 +45,7 @@ pub enum ErrorKind {
     /// A custom error that occurs during runtime.
     ///
     /// This can be used for returning user-defined errors from callbacks.
-    ExternalError(Box<RuntimeError + 'static>),
+    ExternalError(Box<dyn RuntimeError + 'static>),
     /// An error specifying the variable that was called as a function was not a function.
     NotAFunction,
 }
@@ -304,13 +304,13 @@ pub trait RuntimeError: fmt::Debug {
     }
 }
 
-impl RuntimeError {
+impl dyn RuntimeError {
     /// Attempts to downcast this failure to a concrete type by reference.
     ///
     /// If the underlying error is not of type `T`, this will return `None`.
     pub fn downcast_ref<T: RuntimeError + 'static>(&self) -> Option<&T> {
         if self.__private_get_type_id__() == TypeId::of::<T>() {
-            unsafe { Some(&*(self as *const RuntimeError as *const T)) }
+            unsafe { Some(&*(self as *const dyn RuntimeError as *const T)) }
         } else {
             None
         }

--- a/ducc/src/function.rs
+++ b/ducc/src/function.rs
@@ -115,7 +115,8 @@ pub(crate) fn create_callback<'ducc, 'callback>(
     unsafe extern "C" fn finalizer(ctx: *mut ffi::duk_context) -> ffi::duk_ret_t {
         ffi::duk_require_stack(ctx, 1);
         ffi::duk_get_prop_string(ctx, 0, FUNC.as_ptr());
-        Box::from_raw(ffi::duk_get_pointer(ctx, -1) as *mut Callback);
+        let callback = Box::from_raw(ffi::duk_get_pointer(ctx, -1) as *mut Callback);
+        drop(callback);
         ffi::duk_pop(ctx);
         ffi::duk_push_undefined(ctx);
         ffi::duk_put_prop_string(ctx, 0, FUNC.as_ptr());

--- a/ducc/src/types.rs
+++ b/ducc/src/types.rs
@@ -30,6 +30,6 @@ impl<'ducc> Drop for Ref<'ducc> {
 }
 
 pub(crate) type Callback<'ducc, 'a> =
-    Box<Fn(&'ducc Ducc, Value<'ducc>, Values<'ducc>) -> Result<Value<'ducc>> + 'a>;
+    Box<dyn Fn(&'ducc Ducc, Value<'ducc>, Values<'ducc>) -> Result<Value<'ducc>> + 'a>;
 
-pub(crate) type AnyMap = BTreeMap<String, Box<Any + 'static>>;
+pub(crate) type AnyMap = BTreeMap<String, Box<dyn Any + 'static>>;

--- a/ducc/src/util.rs
+++ b/ducc/src/util.rs
@@ -5,7 +5,7 @@ use ffi;
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_void};
 use std::{process, ptr, slice};
-use std::sync::{Once, ONCE_INIT};
+use std::sync::Once;
 use types::AnyMap;
 
 // Throws an error if `$body` results in a change of `$ctx`'s stack size that isn't exactly equal to
@@ -314,7 +314,7 @@ impl Udata {
 // `duk_context` is created outside of `Ducc`. Long story short: use `Ducc` and don't use
 // `duk_create_heap` directly.
 fn ensure_exec_timeout_check_exists() {
-    static INIT: Once = ONCE_INIT;
+    static INIT: Once = Once::new();
     INIT.call_once(|| {
         unsafe { ffi::ducc_set_exec_timeout_function(Some(timeout_func)); }
     });


### PR DESCRIPTION
This PR fixes warnings when compiling with newer versions of Rust (tested on Rust v1.43.0 nightly, build 442ae7f04)

Fixes #7