### PR TITLE
Fix conversion of standard buffer types

### DIFF
--- a/ducc/src/bytes.rs
+++ b/ducc/src/bytes.rs
@@ -15,7 +15,7 @@ impl<'ducc> Bytes<'ducc> {
             let ctx = ducc.ctx;
             assert_stack!(ctx, 0, {
                 ducc.push_ref(&self.0);
-                assert!(ffi::duk_is_buffer(ctx, -1) != 0);
+                assert!(ffi::duk_is_buffer_data(ctx, -1) != 0);
                 let mut len = 0;
                 let data = ffi::duk_get_buffer_data(ctx, -1, &mut len);
                 assert!(!data.is_null());

--- a/ducc/src/ducc.rs
+++ b/ducc/src/ducc.rs
@@ -379,17 +379,16 @@ impl Ducc {
                 ffi::DUK_TYPE_STRING => {
                     Value::String(String(self.pop_ref()))
                 },
-                ffi::DUK_TYPE_OBJECT if ffi::duk_is_buffer_data(self.ctx, -1) == 0 => {
-                    if ffi::duk_is_function(self.ctx, -1) != 0 {
+                ffi::DUK_TYPE_OBJECT | ffi::DUK_TYPE_BUFFER => {
+                    if ffi::duk_is_buffer_data(self.ctx, -1) != 0 {
+                        Value::Bytes(Bytes(self.pop_ref()))
+                    } else if ffi::duk_is_function(self.ctx, -1) != 0 {
                         Value::Function(Function(self.pop_ref()))
                     } else if ffi::duk_is_array(self.ctx, -1) != 0 {
                         Value::Array(Array(self.pop_ref()))
                     } else {
                         Value::Object(Object(self.pop_ref()))
                     }
-                },
-                ffi::DUK_TYPE_BUFFER | _ if ffi::duk_is_buffer_data(self.ctx, -1) != 0 => {
-                    Value::Bytes(Bytes(self.pop_ref()))
                 },
                 _ => Value::Undefined,
             }

--- a/ducc/src/ducc.rs
+++ b/ducc/src/ducc.rs
@@ -379,7 +379,7 @@ impl Ducc {
                 ffi::DUK_TYPE_STRING => {
                     Value::String(String(self.pop_ref()))
                 },
-                ffi::DUK_TYPE_OBJECT => {
+                ffi::DUK_TYPE_OBJECT if ffi::duk_is_buffer_data(self.ctx, -1) == 0 => {
                     if ffi::duk_is_function(self.ctx, -1) != 0 {
                         Value::Function(Function(self.pop_ref()))
                     } else if ffi::duk_is_array(self.ctx, -1) != 0 {
@@ -388,7 +388,7 @@ impl Ducc {
                         Value::Object(Object(self.pop_ref()))
                     }
                 },
-                ffi::DUK_TYPE_BUFFER => {
+                ffi::DUK_TYPE_BUFFER | _ if ffi::duk_is_buffer_data(self.ctx, -1) != 0 => {
                     Value::Bytes(Bytes(self.pop_ref()))
                 },
                 _ => Value::Undefined,

--- a/ducc/src/tests/ducc.rs
+++ b/ducc/src/tests/ducc.rs
@@ -3,6 +3,20 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::time::{Duration, Instant};
 use value::Value;
+use bytes::Bytes;
+
+#[test]
+fn bytes_value() {
+    let ducc = Ducc::new();
+
+    // Standard buffer type
+    let _: () = ducc.exec("a = new Uint8Array();", None, ExecSettings::default()).unwrap();
+    let _: Bytes = ducc.globals().get("a").unwrap();
+
+    // Plain (Duktape's own) buffer type
+    let _: () = ducc.exec("b = Uint8Array.allocPlain(8);", None, ExecSettings::default()).unwrap();
+    let _: Bytes = ducc.globals().get("b").unwrap();
+}
 
 #[test]
 #[should_panic]


### PR DESCRIPTION
Duktape has two buffer types: the built-in "plain" buffer and the standard buffer types (`Uint8Array`). This fixes Ducc only accepting the plain ones.