### PR TITLE
Convert undefined to None

### DIFF
--- a/ducc/src/conversion.rs
+++ b/ducc/src/conversion.rs
@@ -47,7 +47,7 @@ impl<'ducc, T: ToValue<'ducc>> ToValue<'ducc> for Option<T> {
 impl<'ducc, T: FromValue<'ducc>> FromValue<'ducc> for Option<T> {
     fn from_value(value: Value<'ducc>, ducc: &'ducc Ducc) -> Result<Self> {
         match value {
-            Value::Null => Ok(None),
+            Value::Null | Value::Undefined => Ok(None),
             value => Ok(Some(T::from_value(value, ducc)?)),
         }
     }

--- a/ducc/src/tests/conversion.rs
+++ b/ducc/src/tests/conversion.rs
@@ -15,6 +15,8 @@ fn option() {
 
     let none: Option<usize> = FromValue::from_value(none_val.clone(), &ducc).unwrap();
     assert_eq!(none, None::<usize>);
+    let undefined: Option<usize> = FromValue::from_value(Value::Undefined, &ducc).unwrap();
+    assert_eq!(undefined, None::<usize>);
     let some_num: Option<usize> = FromValue::from_value(num_val.clone(), &ducc).unwrap();
     assert_eq!(some_num, Some(123));
     let num: usize = FromValue::from_value(num_val.clone(), &ducc).unwrap();


### PR DESCRIPTION
I don't think there's any reason to map undefined to `Some`