### PR TITLE
Include stack in RuntimeError

### DIFF
--- a/ducc/src/error.rs
+++ b/ducc/src/error.rs
@@ -36,6 +36,8 @@ pub enum ErrorKind {
         code: RuntimeErrorCode,
         /// A string representation of the type of error.
         name: String,
+        /// Printable traceback related to the error
+        stack: Option<String>
     },
     /// A mutable callback has triggered JavaScript code that has called the same mutable callback
     /// again.
@@ -155,8 +157,12 @@ impl fmt::Display for Error {
             ErrorKind::FromJsConversionError { from, to } => {
                 write!(fmt, "error converting JavaScript {} to {}", from, to)
             },
-            ErrorKind::RuntimeError { ref name, .. } => {
-                write!(fmt, "JavaScript runtime error ({})", name)
+            ErrorKind::RuntimeError { ref name, ref stack, .. } => {
+                let stack = match stack {
+                    Some(s) => s,
+                    None => ""
+                };
+                write!(fmt, "JavaScript runtime error ({}): {}", name, stack)
             },
             ErrorKind::RecursiveMutCallback => write!(fmt, "mutable callback called recursively"),
             ErrorKind::NotAFunction => write!(fmt, "tried to a call a non-function"),

--- a/ducc/src/tests/util.rs
+++ b/ducc/src/tests/util.rs
@@ -2,6 +2,7 @@ use ducc::{Ducc, ExecSettings};
 use ffi;
 use value::Value;
 use util::*;
+use error::{Error, ErrorKind};
 
 #[test]
 fn test_assert_stack() {
@@ -81,4 +82,16 @@ fn test_throw_non_object_error() {
     assert!(ducc.exec::<Value>("throw true", None, ExecSettings::default()).is_err());
     assert!(ducc.exec::<Value>("throw undefined", None, ExecSettings::default()).is_err());
     assert!(ducc.exec::<Value>("throw null", None, ExecSettings::default()).is_err());
+}
+
+#[test]
+fn test_pop_error_stack() {
+    let ducc = Ducc::new();
+    let stack = match ducc.exec::<Value>("(function woah() { throw new TypeError('nope') })()", Some("file"), ExecSettings::default()) {
+        Err(Error { kind: ErrorKind::RuntimeError { stack: Some(stack), ..}, .. }) => {
+            stack
+        },
+        _ => panic!()
+    };
+    assert!(stack.contains("woah"));
 }

--- a/ducc/src/util.rs
+++ b/ducc/src/util.rs
@@ -173,6 +173,7 @@ pub(crate) unsafe fn pop_error(ctx: *mut ffi::duk_context) -> Error {
                 kind: ErrorKind::RuntimeError {
                     code: RuntimeErrorCode::Error,
                     name: "Error".to_string(),
+                    stack: None
                 },
                 context: vec![],
             };
@@ -204,6 +205,9 @@ pub(crate) unsafe fn pop_error(ctx: *mut ffi::duk_context) -> Error {
         ffi::duk_get_prop_string(ctx, -1, cstr!("message"));
         let message = get_string(ctx, -1);
         ffi::duk_pop(ctx);
+        ffi::duk_get_prop_string(ctx, -1, cstr!("stack"));
+        let stack = get_string(ctx, -1);
+        ffi::duk_pop(ctx);
 
         let name = match name.is_empty() {
             false => name,
@@ -215,10 +219,15 @@ pub(crate) unsafe fn pop_error(ctx: *mut ffi::duk_context) -> Error {
             true => vec![],
         };
 
+        let stack = match stack.is_empty() {
+            false => Some(stack),
+            true => None,
+        };
+
         ffi::duk_pop(ctx);
 
         Error {
-            kind: ErrorKind::RuntimeError { code, name },
+            kind: ErrorKind::RuntimeError { code, name, stack },
             context: message,
         }
     })


### PR DESCRIPTION
I think including stack in errors is definitely a good thing, *but*
- Should it be in other ErrorKinds than RuntimeError? Probably not since it might not really be feasible to even get the stack for those.
- Should the stack just be blindly appended in `fmt`?
- This breaks backward compat due to new struct item, but user code shouldn't even use `ErrorKind::RuntimeError`
- It would be amazing if the stack of the caller of Rust code that errors with `Error::External` would be recorded in a stack somewhere
  - If we want at least Rust location to be in there, `#[track_caller]` might be useful (stabilizes in 1.46 https://github.com/rust-lang/rust/pull/72445/files#diff-23e04906de6f359a78328a93305eca79R228)
  - Otherwise it's probably possible to get the stack trace from https://duktape.org/api.html#duk_safe_to_stacktrace and add it to the error in push_error, although this requires a duk-sys update as well

The whole output of `fmt` looks like this:
```
nope: JavaScript runtime error (TypeError): TypeError: nope
    at woah (file:1)
    at eval (file:1) preventsyield
```