### PR TITLE
Invalid memory reference

### DIFF
--- a/ducc/src/tests/ducc.rs
+++ b/ducc/src/tests/ducc.rs
@@ -89,6 +89,20 @@ fn user_data_get() {
 }
 
 #[test]
+fn cleanup_ducc_reference() {
+    let ducc = Ducc::new();
+    let o = ducc.create_object();
+    ducc.globals().set("Fun", ducc.create_function(|inv| {
+        Ok(())
+    }));
+    let _: () = ducc.exec(r#"
+        const subClass = (function() {});
+        subClass.__proto__ = Fun;
+    "#, None, ExecSettings::default()).unwrap();
+}
+
+
+#[test]
 fn user_data_remove() {
     let mut ducc = Ducc::new();
     let (count, data) = make_test_user_data();


### PR DESCRIPTION
This is a repro in test form for `SIGSEGV: invalid memory reference` I mentioned in the other PR. When running this test I get a `  process didn't exit successfully: [..] (signal: 11, SIGSEGV: invalid memory reference)`.

@SkylerLipthay would you be able to confirm if this happens for you as well? I'm not sure if it's due to Duktape or Ducc.

It only happens when Drop trait impl for Ducc calls `duk_destroy_heap`, so not *that* critical by any means.