### PR TITLE
Add to_str for fewer memory copies

### DIFF
--- a/ducc/src/string.rs
+++ b/ducc/src/string.rs
@@ -1,8 +1,8 @@
 use cesu8::from_cesu8;
 use error::{Error, Result};
 use ffi;
-use std::slice;
 use std::borrow::Cow;
+use std::slice;
 use std::string::String as StdString;
 use types::Ref;
 
@@ -31,10 +31,7 @@ impl<'ducc> String<'ducc> {
     ///
     /// Otherwise, returns a copy of the string converted to UTF-8.
     pub fn to_str(&self) -> Result<Cow<str>> {
-        match from_cesu8(self.as_bytes()) {
-            Ok(string) => Ok(string),
-            Err(_) => Err(Error::from_js_conversion("string", "String"))
-        }
+        from_cesu8(self.as_bytes()).map_err(|_| Error::from_js_conversion("string", "Cow<str>"))
     }
 
     /// Returns the bytes that make up this string, without a trailing nul byte. This is a CESU-8

--- a/ducc/src/string.rs
+++ b/ducc/src/string.rs
@@ -2,6 +2,7 @@ use cesu8::from_cesu8;
 use error::{Error, Result};
 use ffi;
 use std::slice;
+use std::borrow::Cow;
 use std::string::String as StdString;
 use types::Ref;
 
@@ -17,6 +18,21 @@ impl<'ducc> String<'ducc> {
     pub fn to_string(&self) -> Result<StdString> {
         match from_cesu8(self.as_bytes()) {
             Ok(string) => Ok(string.into_owned()),
+            Err(_) => Err(Error::from_js_conversion("string", "String"))
+        }
+    }
+
+    /// Returns a Rust string converted from the Duktape string as long as it can be converted from
+    /// CESU-8 to UTF-8.
+    ///
+    /// If the underlying Duktape string is already a valid UTF-8 string, this function
+    /// will return a direct pointer to the underlying character data (i.e. no string data
+    /// will be cloned).
+    ///
+    /// Otherwise, returns a copy of the string converted to UTF-8.
+    pub fn to_str(&self) -> Result<Cow<str>> {
+        match from_cesu8(self.as_bytes()) {
+            Ok(string) => Ok(string),
             Err(_) => Err(Error::from_js_conversion("string", "String"))
         }
     }

--- a/ducc/src/tests/string.rs
+++ b/ducc/src/tests/string.rs
@@ -18,3 +18,15 @@ fn compare() {
     with_str("test", |s| assert_eq!(s, Cow::from(b"test".to_vec()))); // Cow (owned)
     with_str("test", |s| assert_eq!(s, s)); // ducc::String
 }
+
+#[test]
+fn nocopy_string() {
+    let ducc = Ducc::new();
+    let string1 = ducc.create_string("foo").unwrap();
+    let string2 = ducc.create_string("foo").unwrap();
+
+    assert!(std::ptr::eq(
+        string1.to_str().unwrap().as_ref(),
+        string2.to_str().unwrap().as_ref()
+    ));
+}


### PR DESCRIPTION
Sorry for bombarding the repo with PRs, but there is no hurry with these :)

If the (interned?) Duktape string is already valid UTF-8, there is no need to copy it at all. This can be achieved with the new `to_str`.

I think this also means that `impl<'ducc> FromValue<'ducc> for &'ducc str` could be implemented, but I'm not sure about ramifications of that.